### PR TITLE
Fixed issue caused by no link to std math library

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ INCLUDES=-I$(shell pwd)/include
 CPPFLAGS=$(INCLUDES) -DVERSION="\"$(VERSION)\"" -DDEFAULT_GCODE_TYPE=emc
 
 LD=gcc
-LIBS=-lstdc++
+LIBS=-lstdc++ -lm
 LDFLAGS=$(LIBS)
 
 SRCDIR=src


### PR DESCRIPTION
```
gcc -lstdc++ obj/main.o obj/parser.o obj/pcb-probe.o -o pcb-probe
/usr/bin/ld: obj/pcb-probe.o: undefined reference to symbol 'ceill@@GLIBC_2.2.5'
/usr/lib/libm.so.6: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
Makefile:33: recipe for target 'pcb-probe' failed
make: *** [pcb-probe] Error 1
```