### PR TITLE
Parse codes such as G00 X00Y00 (no space between axes)

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -11,7 +11,7 @@ double ParseNumber(string &line, unsigned int &pos)
     double result = 0.0;
     string str = "";
 
-    while (pos < line.length() && !isspace(line[pos]))
+    while (pos < line.length() && !isalpha(line[pos]) && !isspace(line[pos]))
         str += line[pos++];
 
     result = atof(str.c_str());
@@ -47,7 +47,7 @@ string NextToken(string &line, unsigned int &pos)
             case ';': // Comment
                 return result;
             case 'X': //generate lines with no commands, we assume last move command
-            case 'Y': 
+            case 'Y':
                 pos = 0;
                 return last_result;
             case 'S':


### PR DESCRIPTION
The G-code parser fails to detect additional axes if there's no space between them. For example, 
G00 X0.123Y0.456
will only consider the X coordinate and will ignore the Y coordinate (the error remains hidden by **atof** specifics).

With this change, it will also cover cases like the one above.